### PR TITLE
Removed reference to unused webpacker function.

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,7 +6,6 @@
     <%= csp_meta_tag %>
 
     <%= stylesheet_link_tag 'application', media: 'all' %>
-    <%= javascript_pack_tag 'application' %>
   </head>
 
   <body>


### PR DESCRIPTION
This function causes the server to return a 500 error if webpacker is not installed. If this solution causes issues elsewhere, it may be a good idea to re-add webpacker to the Gemfile.